### PR TITLE
Work around Flathub not recognizing <developer/> metainfo elements

### DIFF
--- a/io.github.bothlab.syntalos.yaml
+++ b/io.github.bothlab.syntalos.yaml
@@ -223,3 +223,10 @@ modules:
       tag: v1.0.1
     - type: patch
       path: patches/01_fix-old-flatpak.patch
+
+
+# FIXME: This module can be deleted once Flathub recognizes AppStream 1.0 metadata
+- name: metainfo-flathub-legacy-fix
+  buildsystem: simple
+  build-commands:
+    - sed -i '/^<\/component>/i   <developer_name>Matthias Klumpp</developer_name>' /app/share/metainfo/io.github.bothlab.syntalos.metainfo.xml


### PR DESCRIPTION
We postprocess our MetaInfo file with appstreamcli, which in the 23.08 runtime only produces AppStream 1.0 compliant metadata that Flathub doesn't seem to read properly yet.

So we need to add a hack to make this work for now.